### PR TITLE
[Feature request] add WriteBack Message Store Wrapper For Large-Scale Traffic

### DIFF
--- a/quickfixj-core/src/main/java/quickfix/JdbcWriteBackStore.java
+++ b/quickfixj-core/src/main/java/quickfix/JdbcWriteBackStore.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+class JdbcWriteBackStore implements MessageStore {
+
+    private final MessageStore jdbcStore;
+    private final WriteBackStore writeBackStore;
+
+    public JdbcWriteBackStore(MessageStore jdbcStore, WriteBackStore writeBackStore) {
+        this.jdbcStore = jdbcStore;
+        this.writeBackStore = this.initializeWriteBackStore(writeBackStore);
+    }
+
+    private WriteBackStore initializeWriteBackStore(WriteBackStore writeBackStore) {
+        if (writeBackStore == null) {
+            writeBackStore = new MemoryWriteBackStore();
+        }
+
+        writeBackStore.enableScheduling();
+        return writeBackStore;
+    }
+
+    @Override
+    public boolean set(int sequence, String message) throws IOException {
+        return writeBackStore.preserve(sequence, message);
+    }
+
+    /**
+     * Default JdbcStore Wrapper
+     */
+    @Override
+    public void get(int startSequence, int endSequence, Collection<String> messages) throws IOException {
+        jdbcStore.get(startSequence, endSequence, messages);
+    }
+
+    @Override
+    public int getNextSenderMsgSeqNum() throws IOException {
+        return jdbcStore.getNextSenderMsgSeqNum();
+    }
+
+    @Override
+    public int getNextTargetMsgSeqNum() throws IOException {
+        return jdbcStore.getNextTargetMsgSeqNum();
+    }
+
+    @Override
+    public void setNextSenderMsgSeqNum(int next) throws IOException {
+        jdbcStore.setNextSenderMsgSeqNum(next);
+    }
+
+    @Override
+    public void setNextTargetMsgSeqNum(int next) throws IOException {
+        jdbcStore.setNextTargetMsgSeqNum(next);
+    }
+
+    @Override
+    public void incrNextSenderMsgSeqNum() throws IOException {
+        jdbcStore.incrNextSenderMsgSeqNum();
+    }
+
+    @Override
+    public void incrNextTargetMsgSeqNum() throws IOException {
+        jdbcStore.incrNextTargetMsgSeqNum();
+    }
+
+    @Override
+    public Date getCreationTime() throws IOException {
+        return jdbcStore.getCreationTime();
+    }
+
+    @Override
+    public void reset() throws IOException {
+        jdbcStore.reset();
+    }
+
+    @Override
+    public void refresh() throws IOException {
+        jdbcStore.refresh();
+    }
+
+    public interface WriteBackStore {
+        boolean preserve(int sequence, String message);
+
+        void enableScheduling();
+
+        void writeBack() throws RuntimeException;
+    }
+
+    public class MemoryWriteBackStore implements WriteBackStore {
+
+        private final ConcurrentHashMap<Integer, String> CACHE = new ConcurrentHashMap<>();
+
+        @Override
+        public boolean preserve(int sequence, String message) {
+            CACHE.put(sequence, message);
+            return true;
+        }
+
+        @Override
+        public void enableScheduling() throws RuntimeException {
+            Executors.newSingleThreadScheduledExecutor().scheduleWithFixedDelay(
+                    this::writeBack,
+                    0,
+                    100,
+                    TimeUnit.MILLISECONDS
+            );
+        }
+
+        @Override
+        public void writeBack() throws RuntimeException {
+            List<Integer> sequences = CACHE.keySet()
+                    .stream()
+                    .sorted()
+                    .collect(Collectors.toList());
+
+            for (final int sequence : sequences) {
+                String message = CACHE.get(sequence);
+                try {
+                    jdbcStore.set(sequence, message);
+                    CACHE.remove(sequence);
+                } catch (IOException e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        }
+    }
+}

--- a/quickfixj-core/src/main/java/quickfix/JdbcWriteBackStoreFactory.java
+++ b/quickfixj-core/src/main/java/quickfix/JdbcWriteBackStoreFactory.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) quickfixengine.org  All rights reserved.
+ *
+ * This file is part of the QuickFIX FIX Engine
+ *
+ * This file may be distributed under the terms of the quickfixengine.org
+ * license as defined by quickfixengine.org and appearing in the file
+ * LICENSE included in the packaging of this file.
+ *
+ * This file is provided AS IS with NO WARRANTY OF ANY KIND, INCLUDING
+ * THE WARRANTY OF DESIGN, MERCHANTABILITY AND FITNESS FOR A
+ * PARTICULAR PURPOSE.
+ *
+ * See http://www.quickfixengine.org/LICENSE for licensing information.
+ *
+ * Contact ask@quickfixengine.org if any conditions of this licensing
+ * are not clear to you.
+ ******************************************************************************/
+
+package quickfix;
+
+/**
+ * Creates a generic JDBC WriteBack message store.
+ */
+public class JdbcWriteBackStoreFactory implements MessageStoreFactory {
+    private final SessionSettings settings;
+    private final JdbcWriteBackStore.MemoryWriteBackStore memoryWriteBackStore;
+
+    /**
+     * Create a factory using session settings.
+     */
+    public JdbcWriteBackStoreFactory(SessionSettings settings, JdbcWriteBackStore.MemoryWriteBackStore memoryWriteBackStore) {
+        this.settings = settings;
+        this.memoryWriteBackStore = memoryWriteBackStore;
+    }
+
+    /**
+     * Create a JDBC WriteBack message store.
+     *
+     * @param sessionID the sessionID for the message store.
+     */
+    public MessageStore create(SessionID sessionID) {
+        try {
+            JdbcStoreFactory jdbcStoreFactory = new JdbcStoreFactory(settings);
+            return new JdbcWriteBackStore(jdbcStoreFactory.create(sessionID), memoryWriteBackStore);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Used to support the MySQL-specific class (JNI compatibility)
+     *
+     * @return the session settings
+     */
+    protected SessionSettings getSettings() {
+        return settings;
+    }
+}

--- a/quickfixj-core/src/test/java/quickfix/JdbcStoreTest.java
+++ b/quickfixj-core/src/test/java/quickfix/JdbcStoreTest.java
@@ -169,4 +169,22 @@ public class JdbcStoreTest extends AbstractMessageStoreTest {
         store.get(1, 1, messages);
         assertEquals("MESSAGE2", messages.get(0));
     }
+
+    public void testWriteBackMessageUpdate() throws Exception {
+        JdbcStore jdbcStore = (JdbcStore) getMessageStoreFactory().create(getSessionID());
+        JdbcWriteBackStore store = new JdbcWriteBackStore(jdbcStore, null);
+        store.reset();
+
+        assertTrue(store.set(1, "MESSAGE1"));
+        assertTrue(store.set(1, "MESSAGE1-1"));
+        assertTrue(store.set(2, "MESSAGE2"));
+        assertTrue(store.set(3, "MESSAGE3"));
+
+        Thread.sleep(200);
+        List<String> messages = new ArrayList<>();
+        store.get(1, 3, messages);
+        assertEquals("MESSAGE1-1", messages.get(0));
+        assertEquals("MESSAGE2", messages.get(1));
+        assertEquals("MESSAGE3", messages.get(2));
+    }
 }


### PR DESCRIPTION
###  Add WriteBack Message Store Wrapper For Large-Scale Traffic

<img width="1019" alt="image" src="https://github.com/ChoiJunsik/quickfixj-write-back-store/assets/26922008/7ddccaab-4772-4d0e-8859-b0685659a26a">

I've encountered a issue where large-scale traffic leads to a reduced simultaneous throughput due to the Fix Session Lock mechanism. This problem becomes particularly acute when using JdbcStore. 

In our current setup with a Spring-based web server, we're experiencing a bottleneck, with the system only able to process up to 200 Transactions Per Second (TPS).

The core of the problem seems to lie in the store.set() function, which acts as a critical section and is significantly affecting performance. 

To mitigate this, I'm considering the implementation of a write-back pattern for the store.set() function.

### Proposed Solution:

Apply a write-back pattern to the store.set() function to alleviate the bottleneck and enhance throughput.
I'm reaching out to seek advice on the best practices for implementing this solution or to hear alternative suggestions that may resolve the throughput issue more effectively. 

Any insights or guidance would be greatly appreciated.